### PR TITLE
✨ 스킬 CRUD 기능 추가 (Add Skill CRUD functionality)

### DIFF
--- a/prisma/migrations/20250618192734_add_user_id_to_skill/migration.sql
+++ b/prisma/migrations/20250618192734_add_user_id_to_skill/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `user_id` to the `skills` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "skills" ADD COLUMN     "user_id" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,7 @@ model PostAnalysis {
 
 model Skill {
   id          Int            @id @default(autoincrement())
+  userId      Int            @map("user_id")
   name        String
   description String?        @db.Text
   category    SkillCategory?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,22 +139,6 @@ model PostAnalysis {
   @@map("post_analyses")
 }
 
-enum SkillCategory {
-  Language // 프로그래밍 언어
-  Framework // 프레임워크
-  Database // 데이터베이스
-  Cloud // 클라우드
-  Tool // 개발 도구
-  Other // 기타
-}
-
-enum SkillLevel {
-  Beginner // 입문
-  Intermediate // 중급
-  Advanced // 고급
-  Expert // 전문가
-}
-
 model Skill {
   id          Int            @id @default(autoincrement())
   name        String
@@ -172,6 +156,22 @@ model Skill {
   educations  EducationSkillRelation[]
 
   @@map("skills")
+}
+
+enum SkillCategory {
+  Language // 프로그래밍 언어
+  Framework // 프레임워크
+  Database // 데이터베이스
+  Cloud // 클라우드
+  Tool // 개발 도구
+  Other // 기타
+}
+
+enum SkillLevel {
+  Beginner // 입문
+  Intermediate // 중급
+  Advanced // 고급
+  Expert // 전문가
 }
 
 // 경력-기술 관계

--- a/src/server/adapter/out/persistence/skill/index.ts
+++ b/src/server/adapter/out/persistence/skill/index.ts
@@ -1,0 +1,1 @@
+export { SkillRepositoryAdapter } from "./skill.repository.adapter";

--- a/src/server/adapter/out/persistence/skill/mappers/skill.mapper.ts
+++ b/src/server/adapter/out/persistence/skill/mappers/skill.mapper.ts
@@ -1,0 +1,20 @@
+import { Prisma } from "@prisma/client";
+import { Skill } from "~/server/domain/entities/skill";
+import { SkillCategory } from "~/server/domain/entities/skill/skill-category.entity";
+import { SkillLevel } from "~/server/domain/entities/skill/skill-level.entity";
+
+export class SkillMapper {
+  static toDomain(skill: Prisma.SkillGetPayload<object>): Skill {
+    return new Skill({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      category: skill.category ? SkillCategory[skill.category] : null,
+      level: skill.level ? SkillLevel[skill.level] : null,
+      userId: skill.userId,
+      createdAt: skill.createdAt,
+      updatedAt: skill.updatedAt,
+      deletedAt: skill.deletedAt,
+    });
+  }
+}

--- a/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
@@ -28,6 +28,21 @@ export class SkillRepositoryAdapter implements SkillRepository {
     return SkillMapper.toDomain(skill);
   }
 
+  async findSkillById(skillId: number): Promise<Skill | null> {
+    const skill = await this.prismaService.skill.findUnique({
+      where: {
+        id: skillId,
+        deletedAt: null,
+      },
+    });
+
+    if (!skill) {
+      return null;
+    }
+
+    return SkillMapper.toDomain(skill);
+  }
+
   async findSkillsByUserId(userId: number): Promise<Skill[]> {
     const skills = await this.prismaService.skill.findMany({
       where: {

--- a/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
@@ -71,4 +71,11 @@ export class SkillRepositoryAdapter implements SkillRepository {
 
     return SkillMapper.toDomain(skill);
   }
+
+  async deleteSkill(skillId: number): Promise<void> {
+    await this.prismaService.skill.update({
+      where: { id: skillId },
+      data: { deletedAt: new Date() },
+    });
+  }
 }

--- a/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from "~/server/infra/core";
+import { SkillRepository } from "~/server/application/port/out/repositories";
+import { PRISMA_SERVICE, PrismaService } from "~/server/infra/database";
+import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+import { Skill } from "~/server/domain/entities/skill";
+import { SkillMapper } from "./mappers/skill.mapper";
+
+@Injectable()
+export class SkillRepositoryAdapter implements SkillRepository {
+  constructor(
+    @Inject(PRISMA_SERVICE) private readonly prismaService: PrismaService,
+  ) {}
+
+  async createSkill(
+    userId: number,
+    createSkillData: CreateSkillDataDto,
+  ): Promise<Skill> {
+    const skill = await this.prismaService.skill.create({
+      data: {
+        userId,
+        name: createSkillData.name,
+        description: createSkillData.description,
+        category: createSkillData.category,
+        level: createSkillData.level,
+      },
+    });
+
+    return SkillMapper.toDomain(skill);
+  }
+}

--- a/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
@@ -4,6 +4,7 @@ import { PRISMA_SERVICE, PrismaService } from "~/server/infra/database";
 import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
 import { Skill } from "~/server/domain/entities/skill";
 import { SkillMapper } from "./mappers/skill.mapper";
+import { UpdateSkillDataDto } from "~/server/application/dto/update-skill-data.dto";
 
 @Injectable()
 export class SkillRepositoryAdapter implements SkillRepository {
@@ -52,5 +53,22 @@ export class SkillRepositoryAdapter implements SkillRepository {
     });
 
     return skills.map(SkillMapper.toDomain);
+  }
+
+  async updateSkill(
+    skillId: number,
+    updateSkillData: UpdateSkillDataDto,
+  ): Promise<Skill> {
+    const skill = await this.prismaService.skill.update({
+      where: { id: skillId },
+      data: {
+        name: updateSkillData.name,
+        description: updateSkillData.description,
+        category: updateSkillData.category,
+        level: updateSkillData.level,
+      },
+    });
+
+    return SkillMapper.toDomain(skill);
   }
 }

--- a/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/skill/skill.repository.adapter.ts
@@ -27,4 +27,15 @@ export class SkillRepositoryAdapter implements SkillRepository {
 
     return SkillMapper.toDomain(skill);
   }
+
+  async findSkillsByUserId(userId: number): Promise<Skill[]> {
+    const skills = await this.prismaService.skill.findMany({
+      where: {
+        userId,
+        deletedAt: null,
+      },
+    });
+
+    return skills.map(SkillMapper.toDomain);
+  }
 }

--- a/src/server/application/__mocks__/skill/index.ts
+++ b/src/server/application/__mocks__/skill/index.ts
@@ -1,0 +1,2 @@
+export * from "./mocks";
+export { SkillTestFeature } from "./skill-test-feature";

--- a/src/server/application/__mocks__/skill/mocks.ts
+++ b/src/server/application/__mocks__/skill/mocks.ts
@@ -1,0 +1,8 @@
+import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+
+export const mockCreateSkillData: CreateSkillDataDto = {
+  name: "Test Skill",
+  description: "Test Description",
+  category: "Language",
+  level: "Beginner",
+};

--- a/src/server/application/__mocks__/skill/skill-test-feature.ts
+++ b/src/server/application/__mocks__/skill/skill-test-feature.ts
@@ -1,0 +1,24 @@
+import { Skill } from "~/server/domain/entities/skill";
+import { Inject, Injectable } from "~/server/infra/core";
+import {
+  SKILL_REPOSITORY,
+  type SkillRepository,
+} from "../../port/out/repositories";
+import { mockCreateSkillData } from "./mocks";
+
+@Injectable()
+export class SkillTestFeature {
+  constructor(
+    @Inject(SKILL_REPOSITORY) private readonly skillRepository: SkillRepository,
+  ) {}
+
+  async createTestSkill(
+    userId: number,
+    name: string = mockCreateSkillData.name,
+  ): Promise<Skill> {
+    return this.skillRepository.createSkill(userId, {
+      ...mockCreateSkillData,
+      name,
+    });
+  }
+}

--- a/src/server/application/dto/create-skill-data.dto.ts
+++ b/src/server/application/dto/create-skill-data.dto.ts
@@ -1,0 +1,9 @@
+import { SkillCategoryDto } from "./skill-category.dto";
+import { SkillLevelDto } from "./skill-level.dto";
+
+export class CreateSkillDataDto {
+  name: string;
+  description: string | null;
+  category: SkillCategoryDto | null;
+  level: SkillLevelDto | null;
+}

--- a/src/server/application/dto/skill-category.dto.ts
+++ b/src/server/application/dto/skill-category.dto.ts
@@ -1,0 +1,7 @@
+export type SkillCategoryDto =
+  | "Language"
+  | "Framework"
+  | "Database"
+  | "Cloud"
+  | "Tool"
+  | "Other";

--- a/src/server/application/dto/skill-level.dto.ts
+++ b/src/server/application/dto/skill-level.dto.ts
@@ -1,0 +1,1 @@
+export type SkillLevelDto = "Beginner" | "Intermediate" | "Advanced" | "Expert";

--- a/src/server/application/dto/skill.dto.ts
+++ b/src/server/application/dto/skill.dto.ts
@@ -1,0 +1,13 @@
+import { SkillCategoryDto } from "./skill-category.dto";
+import { SkillLevelDto } from "./skill-level.dto";
+
+export class SkillDto {
+  id: number;
+  name: string;
+  description: string | null;
+  category: SkillCategoryDto | null;
+  level: SkillLevelDto | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}

--- a/src/server/application/dto/update-skill-data.dto.ts
+++ b/src/server/application/dto/update-skill-data.dto.ts
@@ -1,0 +1,9 @@
+import { SkillCategoryDto } from "./skill-category.dto";
+import { SkillLevelDto } from "./skill-level.dto";
+
+export class UpdateSkillDataDto {
+  name: string;
+  description: string | null;
+  category: SkillCategoryDto | null;
+  level: SkillLevelDto | null;
+}

--- a/src/server/application/mappers/skill/index.ts
+++ b/src/server/application/mappers/skill/index.ts
@@ -1,0 +1,1 @@
+export { SkillMapper } from "./skill.mapper";

--- a/src/server/application/mappers/skill/skill.mapper.ts
+++ b/src/server/application/mappers/skill/skill.mapper.ts
@@ -1,0 +1,17 @@
+import { Skill } from "~/server/domain/entities/skill";
+import { SkillDto } from "~/server/application/dto/skill.dto";
+
+export class SkillMapper {
+  static toDto(skill: Skill): SkillDto {
+    return {
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      category: skill.category,
+      level: skill.level,
+      createdAt: skill.createdAt,
+      updatedAt: skill.updatedAt,
+      deletedAt: skill.deletedAt,
+    };
+  }
+}

--- a/src/server/application/port/in/skill/create-skill.use-case.spec.ts
+++ b/src/server/application/port/in/skill/create-skill.use-case.spec.ts
@@ -1,0 +1,57 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  CREATE_SKILL_USE_CASE,
+  CreateSkillUseCase,
+} from "./create-skill.use-case";
+import { di } from "~/server/infra/di";
+import { test } from "~/server/infra/test";
+import { User } from "~/server/domain/user";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+
+describe("CreateSkillUseCase", () => {
+  let createSkillUseCase: CreateSkillUseCase;
+  let testUser: User;
+
+  beforeAll(async () => {
+    createSkillUseCase = di.resolve(CREATE_SKILL_USE_CASE);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(createSkillUseCase).toBeDefined();
+  });
+
+  describe("createSkill", () => {
+    test("should create a skill", async () => {
+      // given
+      const createSkillData: CreateSkillDataDto = {
+        name: "Test Skill",
+        description: "Test Description",
+        category: "Language",
+        level: "Beginner",
+      };
+
+      const skill = await createSkillUseCase.createSkill(
+        testUser.id,
+        createSkillData,
+      );
+
+      // then
+      expect(skill).toBeDefined();
+      expect(skill.name).toBe(createSkillData.name);
+      expect(skill.description).toBe(createSkillData.description);
+      expect(skill.category).toBe(createSkillData.category);
+      expect(skill.level).toBe(createSkillData.level);
+      expect(skill.createdAt).toBeDefined();
+      expect(skill.updatedAt).toBeDefined();
+      expect(skill.deletedAt).toBeNull();
+    });
+  });
+});

--- a/src/server/application/port/in/skill/create-skill.use-case.ts
+++ b/src/server/application/port/in/skill/create-skill.use-case.ts
@@ -1,0 +1,11 @@
+import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+import { SkillDto } from "~/server/application/dto/skill.dto";
+
+export const CREATE_SKILL_USE_CASE = Symbol.for("CreateSkillUseCase");
+
+export interface CreateSkillUseCase {
+  createSkill(
+    userId: number,
+    createSkillData: CreateSkillDataDto,
+  ): Promise<SkillDto>;
+}

--- a/src/server/application/port/in/skill/delete-skill.use-case.spec.ts
+++ b/src/server/application/port/in/skill/delete-skill.use-case.spec.ts
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  DELETE_SKILL_USE_CASE,
+  DeleteSkillUseCase,
+} from "./delete-skill.use-case";
+import { SkillTestFeature } from "~/server/application/__mocks__/skill";
+import { User } from "~/server/domain/user";
+import { di } from "~/server/infra/di";
+import { test } from "~/server/infra/test";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { GET_SKILL_USE_CASE, GetSkillUseCase } from "./get-skill.use-case";
+
+describe("DeleteSkillUseCase", () => {
+  let deleteSkillUseCase: DeleteSkillUseCase;
+  let getSkillUseCase: GetSkillUseCase;
+  let skillTestFeature: SkillTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    deleteSkillUseCase = di.resolve(DELETE_SKILL_USE_CASE);
+    getSkillUseCase = di.resolve(GET_SKILL_USE_CASE);
+
+    skillTestFeature = di.resolve(SkillTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(deleteSkillUseCase).toBeDefined();
+  });
+
+  describe("deleteSkill", () => {
+    test("should delete a skill", async () => {
+      // given
+      const createdSkill = await skillTestFeature.createTestSkill(testUser.id);
+
+      // when & then
+      await expect(
+        deleteSkillUseCase.deleteSkill(testUser.id, createdSkill.id),
+      ).resolves.not.toThrowError();
+      const deletedSkill = await getSkillUseCase.getSkill(
+        testUser.id,
+        createdSkill.id,
+      );
+
+      // then
+      expect(deletedSkill).toBeNull();
+    });
+  });
+});

--- a/src/server/application/port/in/skill/delete-skill.use-case.ts
+++ b/src/server/application/port/in/skill/delete-skill.use-case.ts
@@ -1,0 +1,5 @@
+export const DELETE_SKILL_USE_CASE = Symbol.for("DeleteSkillUseCase");
+
+export interface DeleteSkillUseCase {
+  deleteSkill(userId: number, skillId: number): Promise<void>;
+}

--- a/src/server/application/port/in/skill/get-skill.use-case.spec.ts
+++ b/src/server/application/port/in/skill/get-skill.use-case.spec.ts
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { GET_SKILL_USE_CASE, GetSkillUseCase } from "./get-skill.use-case";
+import { di } from "~/server/infra/di";
+import { test } from "~/server/infra/test";
+import { User } from "~/server/domain/user";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { SkillTestFeature } from "~/server/application/__mocks__/skill";
+
+describe("GetSkillUseCase", () => {
+  let getSkillUseCase: GetSkillUseCase;
+  let skillTestFeature: SkillTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    getSkillUseCase = di.resolve(GET_SKILL_USE_CASE);
+
+    skillTestFeature = di.resolve(SkillTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(getSkillUseCase).toBeDefined();
+  });
+
+  describe("getSkillsByUserId", () => {
+    test("사용자가 가지고 있는 모든 기술을 조회할 수 있다.", async () => {
+      // given
+      await skillTestFeature.createTestSkill(testUser.id);
+      await skillTestFeature.createTestSkill(testUser.id, "Test Skill 2");
+
+      const skills = await getSkillUseCase.getSkillsByUserId(testUser.id);
+
+      // then
+      expect(skills).toBeDefined();
+      expect(skills.length).toBe(2);
+
+      skills.forEach((skill) => {
+        expect(skill.id).toBeDefined();
+        expect(skill.name).toBeDefined();
+        expect(skill.description).toBeDefined();
+        expect(skill.category).toBeDefined();
+        expect(skill.level).toBeDefined();
+        expect(skill.createdAt).toBeDefined();
+        expect(skill.updatedAt).toBeDefined();
+        expect(skill.deletedAt).toBeNull();
+      });
+    });
+  });
+});

--- a/src/server/application/port/in/skill/get-skill.use-case.spec.ts
+++ b/src/server/application/port/in/skill/get-skill.use-case.spec.ts
@@ -28,6 +28,31 @@ describe("GetSkillUseCase", () => {
     expect(getSkillUseCase).toBeDefined();
   });
 
+  describe("getSkill", () => {
+    test("사용자가 가지고 있는 기술을 조회할 수 있다.", async () => {
+      // given
+      const skill = await skillTestFeature.createTestSkill(testUser.id);
+
+      // when
+      const result = await getSkillUseCase.getSkill(testUser.id, skill.id);
+
+      if (!result) {
+        throw new Error("Skill not found");
+      }
+
+      // then
+      expect(result).toBeDefined();
+      expect(result.id).toBe(skill.id);
+      expect(result.name).toBe(skill.name);
+      expect(result.description).toBe(skill.description);
+      expect(result.category).toBe(skill.category);
+      expect(result.level).toBe(skill.level);
+      expect(result.createdAt).toBeDefined();
+      expect(result.updatedAt).toBeDefined();
+      expect(result.deletedAt).toBeNull();
+    });
+  });
+
   describe("getSkillsByUserId", () => {
     test("사용자가 가지고 있는 모든 기술을 조회할 수 있다.", async () => {
       // given

--- a/src/server/application/port/in/skill/get-skill.use-case.ts
+++ b/src/server/application/port/in/skill/get-skill.use-case.ts
@@ -1,0 +1,7 @@
+import { SkillDto } from "~/server/application/dto/skill.dto";
+
+export const GET_SKILL_USE_CASE = Symbol.for("GetSkillUseCase");
+
+export interface GetSkillUseCase {
+  getSkillsByUserId(userId: number): Promise<SkillDto[]>;
+}

--- a/src/server/application/port/in/skill/get-skill.use-case.ts
+++ b/src/server/application/port/in/skill/get-skill.use-case.ts
@@ -3,5 +3,6 @@ import { SkillDto } from "~/server/application/dto/skill.dto";
 export const GET_SKILL_USE_CASE = Symbol.for("GetSkillUseCase");
 
 export interface GetSkillUseCase {
+  getSkill(userId: number, skillId: number): Promise<SkillDto | null>;
   getSkillsByUserId(userId: number): Promise<SkillDto[]>;
 }

--- a/src/server/application/port/in/skill/index.ts
+++ b/src/server/application/port/in/skill/index.ts
@@ -2,3 +2,4 @@ export {
   CREATE_SKILL_USE_CASE,
   type CreateSkillUseCase,
 } from "./create-skill.use-case";
+export { GET_SKILL_USE_CASE, type GetSkillUseCase } from "./get-skill.use-case";

--- a/src/server/application/port/in/skill/index.ts
+++ b/src/server/application/port/in/skill/index.ts
@@ -1,0 +1,4 @@
+export {
+  CREATE_SKILL_USE_CASE,
+  type CreateSkillUseCase,
+} from "./create-skill.use-case";

--- a/src/server/application/port/in/skill/index.ts
+++ b/src/server/application/port/in/skill/index.ts
@@ -7,3 +7,7 @@ export {
   UPDATE_SKILL_USE_CASE,
   type UpdateSkillUseCase,
 } from "./update-skill.use-case";
+export {
+  DELETE_SKILL_USE_CASE,
+  type DeleteSkillUseCase,
+} from "./delete-skill.use-case";

--- a/src/server/application/port/in/skill/index.ts
+++ b/src/server/application/port/in/skill/index.ts
@@ -3,3 +3,7 @@ export {
   type CreateSkillUseCase,
 } from "./create-skill.use-case";
 export { GET_SKILL_USE_CASE, type GetSkillUseCase } from "./get-skill.use-case";
+export {
+  UPDATE_SKILL_USE_CASE,
+  type UpdateSkillUseCase,
+} from "./update-skill.use-case";

--- a/src/server/application/port/in/skill/update-skill.use-case.spec.ts
+++ b/src/server/application/port/in/skill/update-skill.use-case.spec.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it, test } from "vitest";
+import {
+  UPDATE_SKILL_USE_CASE,
+  UpdateSkillUseCase,
+} from "./update-skill.use-case";
+import { SkillTestFeature } from "~/server/application/__mocks__/skill";
+import { User } from "~/server/domain/user";
+import { di } from "~/server/infra/di";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { UpdateSkillDataDto } from "~/server/application/dto/update-skill-data.dto";
+
+describe("UpdateSkillUseCase", () => {
+  let updateSkillUseCase: UpdateSkillUseCase;
+  let skillTestFeature: SkillTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    updateSkillUseCase = di.resolve(UPDATE_SKILL_USE_CASE);
+
+    skillTestFeature = di.resolve(SkillTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(updateSkillUseCase).toBeDefined();
+  });
+
+  describe("updateSkill", () => {
+    test("should update a skill", async () => {
+      // given
+      const updateSkillData: UpdateSkillDataDto = {
+        name: "updated name",
+        description: "updated description",
+        category: "Framework",
+        level: "Intermediate",
+      };
+      const createdSkill = await skillTestFeature.createTestSkill(testUser.id);
+
+      // when
+      const updatedSkill = await updateSkillUseCase.updateSkill(
+        testUser.id,
+        createdSkill.id,
+        updateSkillData,
+      );
+
+      // then
+      expect(updatedSkill).toBeDefined();
+      expect(updatedSkill.name).toBe(updateSkillData.name);
+      expect(updatedSkill.description).toBe(updateSkillData.description);
+      expect(updatedSkill.category).toBe(updateSkillData.category);
+      expect(updatedSkill.level).toBe(updateSkillData.level);
+      expect(updatedSkill.createdAt).toStrictEqual(createdSkill.createdAt);
+      expect(updatedSkill.updatedAt).not.toStrictEqual(createdSkill.updatedAt);
+      expect(updatedSkill.deletedAt).toBeNull();
+    });
+  });
+});

--- a/src/server/application/port/in/skill/update-skill.use-case.ts
+++ b/src/server/application/port/in/skill/update-skill.use-case.ts
@@ -1,0 +1,12 @@
+import { SkillDto } from "~/server/application/dto/skill.dto";
+import { UpdateSkillDataDto } from "~/server/application/dto/update-skill-data.dto";
+
+export const UPDATE_SKILL_USE_CASE = "UpdateSkillUseCase";
+
+export interface UpdateSkillUseCase {
+  updateSkill(
+    userId: number,
+    skillId: number,
+    updateSkillData: UpdateSkillDataDto,
+  ): Promise<SkillDto>;
+}

--- a/src/server/application/port/out/repositories/index.ts
+++ b/src/server/application/port/out/repositories/index.ts
@@ -3,3 +3,4 @@ export {
   type PostDraftRepository,
 } from "./post-draft.repository";
 export { POST_REPOSITORY, type PostRepository } from "./post.repository";
+export { SKILL_REPOSITORY, type SkillRepository } from "./skill.repository";

--- a/src/server/application/port/out/repositories/skill.repository.ts
+++ b/src/server/application/port/out/repositories/skill.repository.ts
@@ -15,4 +15,5 @@ export interface SkillRepository {
     skillId: number,
     updateSkillData: UpdateSkillDataDto,
   ): Promise<Skill>;
+  deleteSkill(skillId: number): Promise<void>;
 }

--- a/src/server/application/port/out/repositories/skill.repository.ts
+++ b/src/server/application/port/out/repositories/skill.repository.ts
@@ -1,4 +1,5 @@
 import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+import { UpdateSkillDataDto } from "~/server/application/dto/update-skill-data.dto";
 import { Skill } from "~/server/domain/entities/skill/skill.entity";
 
 export const SKILL_REPOSITORY = Symbol.for("SkillRepository");
@@ -10,4 +11,8 @@ export interface SkillRepository {
   ): Promise<Skill>;
   findSkillById(skillId: number): Promise<Skill | null>;
   findSkillsByUserId(userId: number): Promise<Skill[]>;
+  updateSkill(
+    skillId: number,
+    updateSkillData: UpdateSkillDataDto,
+  ): Promise<Skill>;
 }

--- a/src/server/application/port/out/repositories/skill.repository.ts
+++ b/src/server/application/port/out/repositories/skill.repository.ts
@@ -1,0 +1,11 @@
+import { CreateSkillDataDto } from "~/server/application/dto/create-skill-data.dto";
+import { Skill } from "~/server/domain/entities/skill/skill.entity";
+
+export const SKILL_REPOSITORY = Symbol.for("SkillRepository");
+
+export interface SkillRepository {
+  createSkill(
+    userId: number,
+    createSkillData: CreateSkillDataDto,
+  ): Promise<Skill>;
+}

--- a/src/server/application/port/out/repositories/skill.repository.ts
+++ b/src/server/application/port/out/repositories/skill.repository.ts
@@ -8,4 +8,5 @@ export interface SkillRepository {
     userId: number,
     createSkillData: CreateSkillDataDto,
   ): Promise<Skill>;
+  findSkillsByUserId(userId: number): Promise<Skill[]>;
 }

--- a/src/server/application/port/out/repositories/skill.repository.ts
+++ b/src/server/application/port/out/repositories/skill.repository.ts
@@ -8,5 +8,6 @@ export interface SkillRepository {
     userId: number,
     createSkillData: CreateSkillDataDto,
   ): Promise<Skill>;
+  findSkillById(skillId: number): Promise<Skill | null>;
   findSkillsByUserId(userId: number): Promise<Skill[]>;
 }

--- a/src/server/application/services/index.ts
+++ b/src/server/application/services/index.ts
@@ -1,2 +1,3 @@
 export { PostService } from "./post.service";
 export { PostDraftService } from "./post-draft.service";
+export { SkillService } from "./skill.service";

--- a/src/server/application/services/skill.service.ts
+++ b/src/server/application/services/skill.service.ts
@@ -26,6 +26,16 @@ export class SkillService implements CreateSkillUseCase, GetSkillUseCase {
     return SkillMapper.toDto(skill);
   }
 
+  async getSkill(userId: number, skillId: number): Promise<SkillDto | null> {
+    const skill = await this.skillRepository.findSkillById(skillId);
+
+    if (!skill) {
+      return null;
+    }
+
+    return SkillMapper.toDto(skill);
+  }
+
   async getSkillsByUserId(userId: number): Promise<SkillDto[]> {
     const skills = await this.skillRepository.findSkillsByUserId(userId);
 

--- a/src/server/application/services/skill.service.ts
+++ b/src/server/application/services/skill.service.ts
@@ -73,4 +73,18 @@ export class SkillService
 
     return SkillMapper.toDto(updatedSkill);
   }
+
+  async deleteSkill(userId: number, skillId: number): Promise<void> {
+    const skill = await this.skillRepository.findSkillById(skillId);
+
+    if (!skill) {
+      throw new NotFoundError();
+    }
+
+    if (skill.userId !== userId) {
+      throw new ForbiddenError();
+    }
+
+    await this.skillRepository.deleteSkill(skillId);
+  }
 }

--- a/src/server/application/services/skill.service.ts
+++ b/src/server/application/services/skill.service.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from "~/server/infra/core";
+import { CreateSkillUseCase } from "../port/in/skill";
+import {
+  SKILL_REPOSITORY,
+  type SkillRepository,
+} from "../port/out/repositories";
+import { CreateSkillDataDto } from "../dto/create-skill-data.dto";
+import { SkillDto } from "../dto/skill.dto";
+import { SkillMapper } from "../mappers/skill";
+
+@Injectable()
+export class SkillService implements CreateSkillUseCase {
+  constructor(
+    @Inject(SKILL_REPOSITORY) private readonly skillRepository: SkillRepository,
+  ) {}
+
+  async createSkill(
+    userId: number,
+    createSkillData: CreateSkillDataDto,
+  ): Promise<SkillDto> {
+    const skill = await this.skillRepository.createSkill(
+      userId,
+      createSkillData,
+    );
+
+    return SkillMapper.toDto(skill);
+  }
+}

--- a/src/server/application/services/skill.service.ts
+++ b/src/server/application/services/skill.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from "~/server/infra/core";
-import { CreateSkillUseCase } from "../port/in/skill";
+import { CreateSkillUseCase, GetSkillUseCase } from "../port/in/skill";
 import {
   SKILL_REPOSITORY,
   type SkillRepository,
@@ -9,7 +9,7 @@ import { SkillDto } from "../dto/skill.dto";
 import { SkillMapper } from "../mappers/skill";
 
 @Injectable()
-export class SkillService implements CreateSkillUseCase {
+export class SkillService implements CreateSkillUseCase, GetSkillUseCase {
   constructor(
     @Inject(SKILL_REPOSITORY) private readonly skillRepository: SkillRepository,
   ) {}
@@ -24,5 +24,11 @@ export class SkillService implements CreateSkillUseCase {
     );
 
     return SkillMapper.toDto(skill);
+  }
+
+  async getSkillsByUserId(userId: number): Promise<SkillDto[]> {
+    const skills = await this.skillRepository.findSkillsByUserId(userId);
+
+    return skills.map(SkillMapper.toDto);
   }
 }

--- a/src/server/application/services/skill.service.ts
+++ b/src/server/application/services/skill.service.ts
@@ -1,5 +1,9 @@
 import { Inject, Injectable } from "~/server/infra/core";
-import { CreateSkillUseCase, GetSkillUseCase } from "../port/in/skill";
+import {
+  CreateSkillUseCase,
+  GetSkillUseCase,
+  UpdateSkillUseCase,
+} from "../port/in/skill";
 import {
   SKILL_REPOSITORY,
   type SkillRepository,
@@ -7,9 +11,14 @@ import {
 import { CreateSkillDataDto } from "../dto/create-skill-data.dto";
 import { SkillDto } from "../dto/skill.dto";
 import { SkillMapper } from "../mappers/skill";
+import { UpdateSkillDataDto } from "../dto/update-skill-data.dto";
+import { NotFoundError } from "~/shared/error/not-found.error";
+import { ForbiddenError } from "~/shared/error";
 
 @Injectable()
-export class SkillService implements CreateSkillUseCase, GetSkillUseCase {
+export class SkillService
+  implements CreateSkillUseCase, GetSkillUseCase, UpdateSkillUseCase
+{
   constructor(
     @Inject(SKILL_REPOSITORY) private readonly skillRepository: SkillRepository,
   ) {}
@@ -40,5 +49,28 @@ export class SkillService implements CreateSkillUseCase, GetSkillUseCase {
     const skills = await this.skillRepository.findSkillsByUserId(userId);
 
     return skills.map(SkillMapper.toDto);
+  }
+
+  async updateSkill(
+    userId: number,
+    skillId: number,
+    updateSkillData: UpdateSkillDataDto,
+  ): Promise<SkillDto> {
+    const skill = await this.skillRepository.findSkillById(skillId);
+
+    if (!skill) {
+      throw new NotFoundError();
+    }
+
+    if (skill.userId !== userId) {
+      throw new ForbiddenError();
+    }
+
+    const updatedSkill = await this.skillRepository.updateSkill(
+      skillId,
+      updateSkillData,
+    );
+
+    return SkillMapper.toDto(updatedSkill);
   }
 }

--- a/src/server/domain/entities/skill/index.ts
+++ b/src/server/domain/entities/skill/index.ts
@@ -1,0 +1,1 @@
+export { Skill } from "./skill.entity";

--- a/src/server/domain/entities/skill/skill-category.entity.ts
+++ b/src/server/domain/entities/skill/skill-category.entity.ts
@@ -1,0 +1,8 @@
+export enum SkillCategory {
+  Language = "Language",
+  Framework = "Framework",
+  Database = "Database",
+  Cloud = "Cloud",
+  Tool = "Tool",
+  Other = "Other",
+}

--- a/src/server/domain/entities/skill/skill-level.entity.ts
+++ b/src/server/domain/entities/skill/skill-level.entity.ts
@@ -1,0 +1,6 @@
+export enum SkillLevel {
+  Beginner = "Beginner",
+  Intermediate = "Intermediate",
+  Advanced = "Advanced",
+  Expert = "Expert",
+}

--- a/src/server/domain/entities/skill/skill.entity.ts
+++ b/src/server/domain/entities/skill/skill.entity.ts
@@ -3,6 +3,7 @@ import { SkillLevel } from "./skill-level.entity";
 
 interface SkillConstructorArgs {
   id: number;
+  userId: number;
   name: string;
   description: string | null;
   category: SkillCategory | null;
@@ -14,6 +15,7 @@ interface SkillConstructorArgs {
 
 export class Skill {
   readonly id: number;
+  readonly userId: number;
   readonly name: string;
   readonly description: string | null;
   readonly category: SkillCategory | null;
@@ -24,6 +26,7 @@ export class Skill {
 
   constructor(args: SkillConstructorArgs) {
     this.id = args.id;
+    this.userId = args.userId;
     this.name = args.name;
     this.description = args.description;
     this.category = args.category;

--- a/src/server/domain/entities/skill/skill.entity.ts
+++ b/src/server/domain/entities/skill/skill.entity.ts
@@ -1,0 +1,35 @@
+import { SkillCategory } from "./skill-category.entity";
+import { SkillLevel } from "./skill-level.entity";
+
+interface SkillConstructorArgs {
+  id: number;
+  name: string;
+  description: string | null;
+  category: SkillCategory | null;
+  level: SkillLevel | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class Skill {
+  readonly id: number;
+  readonly name: string;
+  readonly description: string | null;
+  readonly category: SkillCategory | null;
+  readonly level: SkillLevel | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly deletedAt: Date | null;
+
+  constructor(args: SkillConstructorArgs) {
+    this.id = args.id;
+    this.name = args.name;
+    this.description = args.description;
+    this.category = args.category;
+    this.level = args.level;
+    this.createdAt = args.createdAt;
+    this.updatedAt = args.updatedAt;
+    this.deletedAt = args.deletedAt;
+  }
+}

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -20,10 +20,13 @@ import {
   GET_POST_USE_CASE,
   UPDATE_POST_USE_CASE,
 } from "~/server/application/port/in/post";
+import {
+  CREATE_SKILL_USE_CASE,
+  GET_SKILL_USE_CASE,
+} from "~/server/application/port/in/skill";
 import { PostDraftService, SkillService } from "~/server/application/services";
 import { DELETE_POST_DRAFT_USE_CASE } from "~/server/application/port/in/post-draft/delete-post-draft.use-case";
 import { PostRepositoryAdapter } from "~/server/adapter/out/persistence/post";
-import { CREATE_SKILL_USE_CASE } from "~/server/application/port/in/skill";
 import { SkillRepositoryAdapter } from "~/server/adapter/out/persistence/skill";
 
 export const di = container;
@@ -51,3 +54,4 @@ di.registerSingleton(DELETE_POST_USE_CASE, PostService);
 
 // skill service
 di.registerSingleton(CREATE_SKILL_USE_CASE, SkillService);
+di.registerSingleton(GET_SKILL_USE_CASE, SkillService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -6,6 +6,7 @@ import { PostService } from "~/server/application/services/post.service";
 import {
   POST_DRAFT_REPOSITORY,
   POST_REPOSITORY,
+  SKILL_REPOSITORY,
 } from "~/server/application/port/out/repositories";
 import { PostDraftRepositoryAdapter } from "~/server/adapter/out/persistence/post-draft";
 import {
@@ -19,9 +20,11 @@ import {
   GET_POST_USE_CASE,
   UPDATE_POST_USE_CASE,
 } from "~/server/application/port/in/post";
-import { PostDraftService } from "~/server/application/services";
+import { PostDraftService, SkillService } from "~/server/application/services";
 import { DELETE_POST_DRAFT_USE_CASE } from "~/server/application/port/in/post-draft/delete-post-draft.use-case";
 import { PostRepositoryAdapter } from "~/server/adapter/out/persistence/post";
+import { CREATE_SKILL_USE_CASE } from "~/server/application/port/in/skill";
+import { SkillRepositoryAdapter } from "~/server/adapter/out/persistence/skill";
 
 export const di = container;
 
@@ -31,6 +34,7 @@ di.registerSingleton(PRISMA_SERVICE, PrismaService);
 // Repository Providers
 di.registerSingleton(POST_DRAFT_REPOSITORY, PostDraftRepositoryAdapter);
 di.registerSingleton(POST_REPOSITORY, PostRepositoryAdapter);
+di.registerSingleton(SKILL_REPOSITORY, SkillRepositoryAdapter);
 
 // Service Providers
 // post draft service
@@ -44,3 +48,6 @@ di.registerSingleton(CREATE_POST_USE_CASE, PostService);
 di.registerSingleton(GET_POST_USE_CASE, PostService);
 di.registerSingleton(UPDATE_POST_USE_CASE, PostService);
 di.registerSingleton(DELETE_POST_USE_CASE, PostService);
+
+// skill service
+di.registerSingleton(CREATE_SKILL_USE_CASE, SkillService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -22,6 +22,7 @@ import {
 } from "~/server/application/port/in/post";
 import {
   CREATE_SKILL_USE_CASE,
+  DELETE_SKILL_USE_CASE,
   GET_SKILL_USE_CASE,
   UPDATE_SKILL_USE_CASE,
 } from "~/server/application/port/in/skill";
@@ -57,3 +58,4 @@ di.registerSingleton(DELETE_POST_USE_CASE, PostService);
 di.registerSingleton(CREATE_SKILL_USE_CASE, SkillService);
 di.registerSingleton(GET_SKILL_USE_CASE, SkillService);
 di.registerSingleton(UPDATE_SKILL_USE_CASE, SkillService);
+di.registerSingleton(DELETE_SKILL_USE_CASE, SkillService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -23,6 +23,7 @@ import {
 import {
   CREATE_SKILL_USE_CASE,
   GET_SKILL_USE_CASE,
+  UPDATE_SKILL_USE_CASE,
 } from "~/server/application/port/in/skill";
 import { PostDraftService, SkillService } from "~/server/application/services";
 import { DELETE_POST_DRAFT_USE_CASE } from "~/server/application/port/in/post-draft/delete-post-draft.use-case";
@@ -55,3 +56,4 @@ di.registerSingleton(DELETE_POST_USE_CASE, PostService);
 // skill service
 di.registerSingleton(CREATE_SKILL_USE_CASE, SkillService);
 di.registerSingleton(GET_SKILL_USE_CASE, SkillService);
+di.registerSingleton(UPDATE_SKILL_USE_CASE, SkillService);


### PR DESCRIPTION
## 설명 (Description)

이 PR은 애플리케이션에 스킬 관리를 위한 CRUD(생성, 조회, 수정, 삭제) 기능을 구현합니다.
This PR implements CRUD (Create, Read, Update, Delete) functionality for skills in the application.

### 추가된 기능 (Features Added)
- 스킬 엔티티 속성 (Skill entity properties):
  - 이름 (name)
  - 설명 (description)
  - 카테고리 (category)
  - 레벨 (level)
  - 사용자 ID (userId, 스킬 소유권)

- CRUD 유스케이스 (CRUD Use Cases):
  - 스킬 생성 (Create Skill)
  - 스킬 조회 (Read Skill)
  - 스킬 수정 (Update Skill)
  - 스킬 삭제 (Delete Skill)
- 도메인 엔티티와 DTO 구현 (Domain entities and DTOs)
- 모든 유스케이스에 대한 테스트 케이스 (Test cases)

### 기술적 세부사항 (Technical Details)
- 클린 아키텍처 원칙에 따라 구현 (Implemented using Clean Architecture principles)
- 필요한 DTO와 매퍼 추가 (Added necessary DTOs and mappers)
- 기능 검증을 위한 테스트 케이스 포함 (Included test cases for validation)

### 테스트 (Testing)
모든 유스케이스에 대한 테스트 파일이 구현되어 있어 기능 검증이 가능합니다.
All use cases have corresponding test files to ensure functionality.

### 추가 참고사항 (Additional Notes)
- 스킬은 userId를 통해 사용자와 연결됩니다 (Skills are associated with users through userId)
- 스킬은 선택적으로 카테고리와 레벨 속성을 가질 수 있습니다 (Skills can have optional category and level attributes)
- 소프트 삭제 기능이 구현되어 있습니다 (deletedAt 필드) (Soft delete functionality is implemented)