### PR TITLE
✨ Career CRUD 기능 구현

### DIFF
--- a/src/server/adapter/out/persistence/career/career.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/career/career.repository.adapter.ts
@@ -146,4 +146,11 @@ export class CareerRepositoryAdapter implements CareerRepository {
 
     return CareerMapper.toDomain(updatedCareer);
   }
+
+  async deleteCareer(careerId: number): Promise<void> {
+    await this.prismaService.client.career.update({
+      where: { id: careerId },
+      data: { deletedAt: new Date() },
+    });
+  }
 }

--- a/src/server/adapter/out/persistence/career/career.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/career/career.repository.adapter.ts
@@ -44,4 +44,36 @@ export class CareerRepositoryAdapter implements CareerRepository {
 
     return CareerMapper.toDomain(career);
   }
+
+  async findCareerById(careerId: number): Promise<Career | null> {
+    const career = await this.prismaService.career.findUnique({
+      where: {
+        id: careerId,
+        deletedAt: null,
+      },
+      include: {
+        achievements: true,
+      },
+    });
+
+    if (!career) {
+      return null;
+    }
+
+    return CareerMapper.toDomain(career);
+  }
+
+  async findCareersByUserId(userId: number): Promise<Career[]> {
+    const careers = await this.prismaService.career.findMany({
+      where: {
+        userId,
+        deletedAt: null,
+      },
+      include: {
+        achievements: true,
+      },
+    });
+
+    return careers.map(CareerMapper.toDomain);
+  }
 }

--- a/src/server/adapter/out/persistence/career/career.repository.adapter.ts
+++ b/src/server/adapter/out/persistence/career/career.repository.adapter.ts
@@ -1,0 +1,47 @@
+import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+import { CareerRepository } from "~/server/application/port/out/repositories";
+import { Career } from "~/server/domain/aggregate/career";
+import { Inject, Injectable } from "~/server/infra/core";
+import { PRISMA_SERVICE, PrismaService } from "~/server/infra/database";
+import { CareerMapper } from "./mappers/career.mapper";
+
+@Injectable()
+export class CareerRepositoryAdapter implements CareerRepository {
+  constructor(
+    @Inject(PRISMA_SERVICE)
+    private readonly prismaService: PrismaService,
+  ) {}
+
+  async createCareer(
+    userId: number,
+    createCareerData: CreateCareerDataDto,
+  ): Promise<Career> {
+    const career = await this.prismaService.career.create({
+      data: {
+        userId,
+        companyName: createCareerData.companyName,
+        position: createCareerData.position,
+        employmentType: createCareerData.employmentType,
+        locationType: createCareerData.locationType,
+        location: createCareerData.location,
+        startDate: createCareerData.startDate,
+        endDate: createCareerData.endDate,
+        isCurrentPosition: createCareerData.isCurrentPosition,
+        description: createCareerData.description,
+        responsibilities: createCareerData.responsibilities,
+        url: createCareerData.url,
+        achievements: {
+          create: createCareerData.achievements.map((achievement) => ({
+            description: achievement.description,
+            metrics: achievement.metrics,
+          })),
+        },
+      },
+      include: {
+        achievements: true,
+      },
+    });
+
+    return CareerMapper.toDomain(career);
+  }
+}

--- a/src/server/adapter/out/persistence/career/index.ts
+++ b/src/server/adapter/out/persistence/career/index.ts
@@ -1,0 +1,1 @@
+export { CareerRepositoryAdapter } from "./career.repository.adapter";

--- a/src/server/adapter/out/persistence/career/mappers/career-archievement.mapper.ts
+++ b/src/server/adapter/out/persistence/career/mappers/career-archievement.mapper.ts
@@ -1,0 +1,18 @@
+import { Prisma } from "@prisma/client";
+import { CareerAchievement } from "~/server/domain/aggregate/career/career-archievement.entity";
+
+export class CareerAchievementMapper {
+  static toDomain(
+    careerAchievement: Prisma.CareerAchievementGetPayload<object>,
+  ): CareerAchievement {
+    return new CareerAchievement({
+      id: careerAchievement.id,
+      careerId: careerAchievement.careerId,
+      description: careerAchievement.description,
+      metrics: careerAchievement.metrics,
+      createdAt: careerAchievement.createdAt,
+      updatedAt: careerAchievement.updatedAt,
+      deletedAt: careerAchievement.deletedAt,
+    });
+  }
+}

--- a/src/server/adapter/out/persistence/career/mappers/career.mapper.ts
+++ b/src/server/adapter/out/persistence/career/mappers/career.mapper.ts
@@ -1,0 +1,35 @@
+import { Prisma } from "@prisma/client";
+import { Career } from "~/server/domain/aggregate/career";
+import { EmploymentType } from "~/server/domain/aggregate/career/employment-type.entity";
+import { LocationType } from "~/server/domain/aggregate/career/location-type.entity";
+import { CareerAchievementMapper } from "./career-archievement.mapper";
+
+type PrismaCareer = Prisma.CareerGetPayload<{
+  include: {
+    achievements: true;
+  };
+}>;
+
+export class CareerMapper {
+  static toDomain(career: PrismaCareer): Career {
+    return new Career({
+      id: career.id,
+      userId: career.userId,
+      companyName: career.companyName,
+      position: career.position,
+      employmentType: EmploymentType[career.employmentType],
+      locationType: LocationType[career.locationType],
+      location: career.location,
+      startDate: career.startDate,
+      endDate: career.endDate,
+      isCurrentPosition: career.isCurrentPosition,
+      description: career.description,
+      responsibilities: career.responsibilities,
+      url: career.url,
+      createdAt: career.createdAt,
+      updatedAt: career.updatedAt,
+      deletedAt: career.deletedAt,
+      achievements: career.achievements.map(CareerAchievementMapper.toDomain),
+    });
+  }
+}

--- a/src/server/application/__mocks__/career/career-test-feature.ts
+++ b/src/server/application/__mocks__/career/career-test-feature.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from "~/server/infra/core";
+import {
+  CAREER_REPOSITORY,
+  type CareerRepository,
+} from "../../port/out/repositories";
+import { mockCreateCareerDataDto } from "./mocks";
+import { Career } from "~/server/domain/aggregate/career";
+
+@Injectable()
+export class CareerTestFeature {
+  constructor(
+    @Inject(CAREER_REPOSITORY)
+    private readonly careerRepository: CareerRepository,
+  ) {}
+
+  async createTestCareer(userId: number): Promise<Career> {
+    const career = await this.careerRepository.createCareer(
+      userId,
+      mockCreateCareerDataDto,
+    );
+
+    return career;
+  }
+}

--- a/src/server/application/__mocks__/career/index.ts
+++ b/src/server/application/__mocks__/career/index.ts
@@ -1,0 +1,2 @@
+export * from "./mocks";
+export { CareerTestFeature } from "./career-test-feature";

--- a/src/server/application/__mocks__/career/mocks.ts
+++ b/src/server/application/__mocks__/career/mocks.ts
@@ -1,0 +1,21 @@
+import { CreateCareerDataDto } from "../../dto/create-career-data.dto";
+
+export const mockCreateCareerDataDto: CreateCareerDataDto = {
+  companyName: "Test Company",
+  position: "Test Position",
+  employmentType: "FullTime",
+  locationType: "Office",
+  location: "Test Location",
+  startDate: new Date(),
+  endDate: null,
+  isCurrentPosition: false,
+  description: "Test Description",
+  responsibilities: "Test Responsibilities",
+  url: "https://test.com",
+  achievements: [
+    {
+      description: "Test Achievement",
+      metrics: "Test Metrics",
+    },
+  ],
+};

--- a/src/server/application/dto/career-archievement.dto.ts
+++ b/src/server/application/dto/career-archievement.dto.ts
@@ -1,0 +1,8 @@
+export class CareerAchievementDto {
+  id: number;
+  careerId: number;
+  description: string;
+  metrics: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/server/application/dto/career.dto.ts
+++ b/src/server/application/dto/career.dto.ts
@@ -1,0 +1,21 @@
+import { CareerAchievementDto } from "./career-archievement.dto";
+import { EmploymentTypeDto } from "./employment-type.dto";
+import { LocationTypeDto } from "./location-type.dto";
+
+export class CareerDto {
+  id: number;
+  companyName: string;
+  position: string;
+  employmentType: EmploymentTypeDto;
+  locationType: LocationTypeDto;
+  location: string | null;
+  startDate: Date;
+  endDate: Date | null;
+  isCurrentPosition: boolean;
+  description: string | null;
+  responsibilities: string | null;
+  url: string | null;
+  achievements: CareerAchievementDto[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/server/application/dto/create-career-archievement-data.dto.ts
+++ b/src/server/application/dto/create-career-archievement-data.dto.ts
@@ -1,0 +1,4 @@
+export class CreateCareerAchievementDataDto {
+  description: string;
+  metrics: string | null;
+}

--- a/src/server/application/dto/create-career-data.dto.ts
+++ b/src/server/application/dto/create-career-data.dto.ts
@@ -1,0 +1,18 @@
+import { CreateCareerAchievementDataDto } from "./create-career-archievement-data.dto";
+import { EmploymentTypeDto } from "./employment-type.dto";
+import { LocationTypeDto } from "./location-type.dto";
+
+export class CreateCareerDataDto {
+  companyName: string;
+  position: string;
+  employmentType: EmploymentTypeDto;
+  locationType: LocationTypeDto;
+  location: string | null;
+  startDate: Date;
+  endDate: Date | null;
+  isCurrentPosition: boolean;
+  description: string | null;
+  responsibilities: string | null;
+  url: string | null;
+  achievements: CreateCareerAchievementDataDto[];
+}

--- a/src/server/application/dto/employment-type.dto.ts
+++ b/src/server/application/dto/employment-type.dto.ts
@@ -1,0 +1,6 @@
+export type EmploymentTypeDto =
+  | "FullTime"
+  | "PartTime"
+  | "Contract"
+  | "Internship"
+  | "Freelance";

--- a/src/server/application/dto/location-type.dto.ts
+++ b/src/server/application/dto/location-type.dto.ts
@@ -1,0 +1,1 @@
+export type LocationTypeDto = "Office" | "Remote" | "Hybrid";

--- a/src/server/application/dto/update-career-archievement-data.dto.ts
+++ b/src/server/application/dto/update-career-archievement-data.dto.ts
@@ -1,0 +1,5 @@
+export class UpdateCareerAchievementDataDto {
+  id: number | null;
+  description: string;
+  metrics: string | null;
+}

--- a/src/server/application/dto/update-career-data.dto.ts
+++ b/src/server/application/dto/update-career-data.dto.ts
@@ -1,0 +1,18 @@
+import { EmploymentTypeDto } from "./employment-type.dto";
+import { LocationTypeDto } from "./location-type.dto";
+import { UpdateCareerAchievementDataDto } from "./update-career-archievement-data.dto";
+
+export class UpdateCareerDataDto {
+  companyName: string;
+  position: string;
+  employmentType: EmploymentTypeDto;
+  locationType: LocationTypeDto;
+  location: string | null;
+  startDate: Date;
+  endDate: Date | null;
+  isCurrentPosition: boolean;
+  description: string | null;
+  responsibilities: string | null;
+  url: string | null;
+  achievements: UpdateCareerAchievementDataDto[];
+}

--- a/src/server/application/mappers/career/career-archievement.mapper.ts
+++ b/src/server/application/mappers/career/career-archievement.mapper.ts
@@ -1,0 +1,15 @@
+import { CareerAchievement } from "~/server/domain/aggregate/career/career-archievement.entity";
+import { CareerAchievementDto } from "../../dto/career-archievement.dto";
+
+export class CareerAchievementMapper {
+  static toDto(careerAchievement: CareerAchievement): CareerAchievementDto {
+    return {
+      id: careerAchievement.id,
+      careerId: careerAchievement.careerId,
+      description: careerAchievement.description,
+      metrics: careerAchievement.metrics,
+      createdAt: careerAchievement.createdAt,
+      updatedAt: careerAchievement.updatedAt,
+    };
+  }
+}

--- a/src/server/application/mappers/career/career.mapper.ts
+++ b/src/server/application/mappers/career/career.mapper.ts
@@ -1,0 +1,25 @@
+import { Career } from "~/server/domain/aggregate/career";
+import { CareerDto } from "../../dto/career.dto";
+import { CareerAchievementMapper } from "./career-archievement.mapper";
+
+export class CareerMapper {
+  static toDto(career: Career): CareerDto {
+    return {
+      id: career.id,
+      companyName: career.companyName,
+      position: career.position,
+      employmentType: career.employmentType,
+      locationType: career.locationType,
+      location: career.location,
+      startDate: career.startDate,
+      endDate: career.endDate,
+      isCurrentPosition: career.isCurrentPosition,
+      description: career.description,
+      responsibilities: career.responsibilities,
+      url: career.url,
+      achievements: career.achievements.map(CareerAchievementMapper.toDto),
+      createdAt: career.createdAt,
+      updatedAt: career.updatedAt,
+    };
+  }
+}

--- a/src/server/application/mappers/career/index.ts
+++ b/src/server/application/mappers/career/index.ts
@@ -1,0 +1,1 @@
+export { CareerMapper } from "./career.mapper";

--- a/src/server/application/port/in/career/create-career.use-case.spec.ts
+++ b/src/server/application/port/in/career/create-career.use-case.spec.ts
@@ -6,7 +6,7 @@ import {
 import { di } from "~/server/infra/di";
 import { User } from "~/server/domain/aggregate/user";
 import { UserTestFeature } from "~/server/application/__mocks__/user";
-import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+import { mockCreateCareerDataDto } from "~/server/application/__mocks__/career";
 import { test } from "~/server/infra/test";
 
 describe("CreateCareerUseCase", () => {
@@ -31,55 +31,42 @@ describe("CreateCareerUseCase", () => {
   describe("createCareer", () => {
     test("커리어 생성 성공", async () => {
       // given
-      const createCareerData: CreateCareerDataDto = {
-        companyName: "Test Company",
-        position: "Test Position",
-        employmentType: "FullTime",
-        locationType: "Office",
-        location: "Test Location",
-        startDate: new Date(),
-        endDate: null,
-        isCurrentPosition: false,
-        description: "Test Description",
-        responsibilities: "Test Responsibilities",
-        url: "https://test.com",
-        achievements: [
-          {
-            description: "Test Achievement",
-            metrics: "Test Metrics",
-          },
-        ],
-      };
 
       // when
       const career = await createCareerUseCase.createCareer(
         testUser.id,
-        createCareerData,
+        mockCreateCareerDataDto,
       );
 
       // then
       expect(career).toBeDefined();
-      expect(career.companyName).toBe(createCareerData.companyName);
-      expect(career.position).toBe(createCareerData.position);
-      expect(career.employmentType).toBe(createCareerData.employmentType);
-      expect(career.locationType).toBe(createCareerData.locationType);
-      expect(career.location).toBe(createCareerData.location);
-      expect(career.startDate).toStrictEqual(createCareerData.startDate);
-      expect(career.endDate).toStrictEqual(createCareerData.endDate);
-      expect(career.isCurrentPosition).toBe(createCareerData.isCurrentPosition);
-      expect(career.description).toBe(createCareerData.description);
-      expect(career.responsibilities).toBe(createCareerData.responsibilities);
-      expect(career.url).toBe(createCareerData.url);
+      expect(career.companyName).toBe(mockCreateCareerDataDto.companyName);
+      expect(career.position).toBe(mockCreateCareerDataDto.position);
+      expect(career.employmentType).toBe(
+        mockCreateCareerDataDto.employmentType,
+      );
+      expect(career.locationType).toBe(mockCreateCareerDataDto.locationType);
+      expect(career.location).toBe(mockCreateCareerDataDto.location);
+      expect(career.startDate).toStrictEqual(mockCreateCareerDataDto.startDate);
+      expect(career.endDate).toStrictEqual(mockCreateCareerDataDto.endDate);
+      expect(career.isCurrentPosition).toBe(
+        mockCreateCareerDataDto.isCurrentPosition,
+      );
+      expect(career.description).toBe(mockCreateCareerDataDto.description);
+      expect(career.responsibilities).toBe(
+        mockCreateCareerDataDto.responsibilities,
+      );
+      expect(career.url).toBe(mockCreateCareerDataDto.url);
       expect(career.createdAt).toBeDefined();
       expect(career.updatedAt).toBeDefined();
 
       career.achievements.forEach((achievement) => {
         expect(achievement).toBeDefined();
         expect(achievement.description).toBe(
-          createCareerData.achievements[0].description,
+          mockCreateCareerDataDto.achievements[0].description,
         );
         expect(achievement.metrics).toBe(
-          createCareerData.achievements[0].metrics,
+          mockCreateCareerDataDto.achievements[0].metrics,
         );
         expect(achievement.createdAt).toBeDefined();
         expect(achievement.updatedAt).toBeDefined();

--- a/src/server/application/port/in/career/create-career.use-case.spec.ts
+++ b/src/server/application/port/in/career/create-career.use-case.spec.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  CREATE_CAREER_USE_CASE,
+  CreateCareerUseCase,
+} from "./create-career.use-case";
+import { di } from "~/server/infra/di";
+import { User } from "~/server/domain/aggregate/user";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+import { test } from "~/server/infra/test";
+
+describe("CreateCareerUseCase", () => {
+  let createCareerUseCase: CreateCareerUseCase;
+  let testUser: User;
+
+  beforeAll(async () => {
+    createCareerUseCase = di.resolve(CREATE_CAREER_USE_CASE);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", async () => {
+    expect(createCareerUseCase).toBeDefined();
+  });
+
+  describe("createCareer", () => {
+    test("커리어 생성 성공", async () => {
+      // given
+      const createCareerData: CreateCareerDataDto = {
+        companyName: "Test Company",
+        position: "Test Position",
+        employmentType: "FullTime",
+        locationType: "Office",
+        location: "Test Location",
+        startDate: new Date(),
+        endDate: null,
+        isCurrentPosition: false,
+        description: "Test Description",
+        responsibilities: "Test Responsibilities",
+        url: "https://test.com",
+        achievements: [
+          {
+            description: "Test Achievement",
+            metrics: "Test Metrics",
+          },
+        ],
+      };
+
+      // when
+      const career = await createCareerUseCase.createCareer(
+        testUser.id,
+        createCareerData,
+      );
+
+      // then
+      expect(career).toBeDefined();
+      expect(career.companyName).toBe(createCareerData.companyName);
+      expect(career.position).toBe(createCareerData.position);
+      expect(career.employmentType).toBe(createCareerData.employmentType);
+      expect(career.locationType).toBe(createCareerData.locationType);
+      expect(career.location).toBe(createCareerData.location);
+      expect(career.startDate).toStrictEqual(createCareerData.startDate);
+      expect(career.endDate).toStrictEqual(createCareerData.endDate);
+      expect(career.isCurrentPosition).toBe(createCareerData.isCurrentPosition);
+      expect(career.description).toBe(createCareerData.description);
+      expect(career.responsibilities).toBe(createCareerData.responsibilities);
+      expect(career.url).toBe(createCareerData.url);
+      expect(career.createdAt).toBeDefined();
+      expect(career.updatedAt).toBeDefined();
+
+      career.achievements.forEach((achievement) => {
+        expect(achievement).toBeDefined();
+        expect(achievement.description).toBe(
+          createCareerData.achievements[0].description,
+        );
+        expect(achievement.metrics).toBe(
+          createCareerData.achievements[0].metrics,
+        );
+        expect(achievement.createdAt).toBeDefined();
+        expect(achievement.updatedAt).toBeDefined();
+      });
+    });
+  });
+});

--- a/src/server/application/port/in/career/create-career.use-case.ts
+++ b/src/server/application/port/in/career/create-career.use-case.ts
@@ -1,0 +1,11 @@
+import { CareerDto } from "~/server/application/dto/career.dto";
+import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+
+export const CREATE_CAREER_USE_CASE = Symbol.for("CreateCareerUseCase");
+
+export interface CreateCareerUseCase {
+  createCareer(
+    userId: number,
+    createCareerData: CreateCareerDataDto,
+  ): Promise<CareerDto>;
+}

--- a/src/server/application/port/in/career/delete-career.use-case.spec.ts
+++ b/src/server/application/port/in/career/delete-career.use-case.spec.ts
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  DELETE_CAREER_USE_CASE,
+  DeleteCareerUseCase,
+} from "./delete-career.use-case";
+import { di } from "~/server/infra/di";
+import { test } from "~/server/infra/test";
+import { CareerTestFeature } from "~/server/application/__mocks__/career";
+import { User } from "~/server/domain/aggregate/user";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { GET_CAREER_USE_CASE, GetCareerUseCase } from "./get-career.use-case";
+
+describe("DeleteCareerUseCase", () => {
+  let deleteCareerUseCase: DeleteCareerUseCase;
+  let getCareerUseCase: GetCareerUseCase;
+  let careerTestFeature: CareerTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    deleteCareerUseCase = di.resolve(DELETE_CAREER_USE_CASE);
+
+    getCareerUseCase = di.resolve(GET_CAREER_USE_CASE);
+
+    careerTestFeature = di.resolve(CareerTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(deleteCareerUseCase).toBeDefined();
+  });
+
+  describe("deleteCareer", () => {
+    test("커리어 삭제 성공", async () => {
+      // given
+      const createdCareer = await careerTestFeature.createTestCareer(
+        testUser.id,
+      );
+
+      // when
+      await expect(
+        deleteCareerUseCase.deleteCareer(testUser.id, createdCareer.id),
+      ).resolves.not.toThrowError();
+      const deletedCareer = await getCareerUseCase.getCareer(createdCareer.id);
+
+      // then
+      expect(deletedCareer).toBeNull();
+    });
+  });
+});

--- a/src/server/application/port/in/career/delete-career.use-case.ts
+++ b/src/server/application/port/in/career/delete-career.use-case.ts
@@ -1,0 +1,5 @@
+export const DELETE_CAREER_USE_CASE = Symbol.for("DeleteCareerUseCase");
+
+export interface DeleteCareerUseCase {
+  deleteCareer(userId: number, careerId: number): Promise<void>;
+}

--- a/src/server/application/port/in/career/get-career.use-case.spec.ts
+++ b/src/server/application/port/in/career/get-career.use-case.spec.ts
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it, test } from "vitest";
+import { GET_CAREER_USE_CASE, GetCareerUseCase } from "./get-career.use-case";
+import { di } from "~/server/infra/di";
+import { User } from "~/server/domain/aggregate/user";
+import { CareerTestFeature } from "~/server/application/__mocks__/career";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+
+describe("GetCareerUseCase", () => {
+  let getCareerUseCase: GetCareerUseCase;
+  let careerTestFeature: CareerTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    getCareerUseCase = di.resolve(GET_CAREER_USE_CASE);
+
+    careerTestFeature = di.resolve(CareerTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(getCareerUseCase).toBeDefined();
+  });
+
+  describe("getCareer", () => {
+    test("커리어 조회 성공", async () => {
+      // given
+      const createdCareer = await careerTestFeature.createTestCareer(
+        testUser.id,
+      );
+
+      // when
+      const career = await getCareerUseCase.getCareer(createdCareer.id);
+
+      if (!career) {
+        throw new Error("Career not found");
+      }
+
+      // then
+      expect(career).toBeDefined();
+      expect(career.id).toBe(createdCareer.id);
+      expect(career.companyName).toBe(createdCareer.companyName);
+      expect(career.position).toBe(createdCareer.position);
+      expect(career.employmentType).toBe(createdCareer.employmentType);
+      expect(career.locationType).toBe(createdCareer.locationType);
+      expect(career.location).toBe(createdCareer.location);
+      expect(career.startDate).toStrictEqual(createdCareer.startDate);
+      expect(career.endDate).toStrictEqual(createdCareer.endDate);
+      expect(career.isCurrentPosition).toBe(createdCareer.isCurrentPosition);
+      expect(career.description).toBe(createdCareer.description);
+      expect(career.responsibilities).toBe(createdCareer.responsibilities);
+      expect(career.url).toBe(createdCareer.url);
+      expect(career.createdAt).toBeDefined();
+    });
+
+    test("커리어 조회 실패", async () => {
+      // given
+      const careerId = 0;
+
+      // when
+      const career = await getCareerUseCase.getCareer(careerId);
+
+      // then
+      expect(career).toBeNull();
+    });
+  });
+
+  describe("getCareersByUserId", () => {
+    test("커리어 조회 성공", async () => {
+      // given
+      await Promise.all(
+        Array.from({ length: 3 }, () =>
+          careerTestFeature.createTestCareer(testUser.id),
+        ),
+      );
+
+      // when
+      const careers = await getCareerUseCase.getCareersByUserId(testUser.id);
+
+      // then
+      expect(careers).toBeDefined();
+      expect(careers.length).toBe(3);
+    });
+  });
+});

--- a/src/server/application/port/in/career/get-career.use-case.ts
+++ b/src/server/application/port/in/career/get-career.use-case.ts
@@ -1,0 +1,8 @@
+import { CareerDto } from "~/server/application/dto/career.dto";
+
+export const GET_CAREER_USE_CASE = Symbol("GetCareerUseCase");
+
+export interface GetCareerUseCase {
+  getCareer(careerId: number): Promise<CareerDto | null>;
+  getCareersByUserId(userId: number): Promise<CareerDto[]>;
+}

--- a/src/server/application/port/in/career/index.ts
+++ b/src/server/application/port/in/career/index.ts
@@ -1,0 +1,4 @@
+export {
+  CREATE_CAREER_USE_CASE,
+  type CreateCareerUseCase,
+} from "./create-career.use-case";

--- a/src/server/application/port/in/career/index.ts
+++ b/src/server/application/port/in/career/index.ts
@@ -10,3 +10,7 @@ export {
   UPDATE_CAREER_USE_CASE,
   type UpdateCareerUseCase,
 } from "./update-career.use-case";
+export {
+  DELETE_CAREER_USE_CASE,
+  type DeleteCareerUseCase,
+} from "./delete-career.use-case";

--- a/src/server/application/port/in/career/index.ts
+++ b/src/server/application/port/in/career/index.ts
@@ -2,3 +2,7 @@ export {
   CREATE_CAREER_USE_CASE,
   type CreateCareerUseCase,
 } from "./create-career.use-case";
+export {
+  GET_CAREER_USE_CASE,
+  type GetCareerUseCase,
+} from "./get-career.use-case";

--- a/src/server/application/port/in/career/index.ts
+++ b/src/server/application/port/in/career/index.ts
@@ -6,3 +6,7 @@ export {
   GET_CAREER_USE_CASE,
   type GetCareerUseCase,
 } from "./get-career.use-case";
+export {
+  UPDATE_CAREER_USE_CASE,
+  type UpdateCareerUseCase,
+} from "./update-career.use-case";

--- a/src/server/application/port/in/career/update-career.use-case.spec.ts
+++ b/src/server/application/port/in/career/update-career.use-case.spec.ts
@@ -1,0 +1,109 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  UPDATE_CAREER_USE_CASE,
+  UpdateCareerUseCase,
+} from "./update-career.use-case";
+import { di } from "~/server/infra/di";
+import { CareerTestFeature } from "~/server/application/__mocks__/career";
+import { User } from "~/server/domain/aggregate/user";
+import { UserTestFeature } from "~/server/application/__mocks__/user";
+import { UpdateCareerDataDto } from "~/server/application/dto/update-career-data.dto";
+import { test } from "~/server/infra/test";
+
+describe("UpdateCareerUseCase", () => {
+  let updateCareerUseCase: UpdateCareerUseCase;
+  let careerTestFeature: CareerTestFeature;
+  let testUser: User;
+
+  beforeAll(async () => {
+    updateCareerUseCase = di.resolve(UPDATE_CAREER_USE_CASE);
+
+    careerTestFeature = di.resolve(CareerTestFeature);
+
+    const userTestFeature = di.resolve(UserTestFeature);
+    testUser = await userTestFeature.createTestUser();
+
+    return () => {
+      userTestFeature.deleteTestUser(testUser.id);
+    };
+  });
+
+  it("should be defined", () => {
+    expect(updateCareerUseCase).toBeDefined();
+  });
+
+  describe("updateCareer", () => {
+    test("커리어 수정 성공", async () => {
+      // given
+      const createdCareer = await careerTestFeature.createTestCareer(
+        testUser.id,
+      );
+      const updateCareerData: UpdateCareerDataDto = {
+        companyName: "Updated Company",
+        position: "Updated Position",
+        employmentType: "FullTime",
+        locationType: "Hybrid",
+        location: "Updated Location",
+        startDate: new Date("2023-01-01"),
+        endDate: new Date("2023-12-31"),
+        isCurrentPosition: false,
+        description: "Updated description",
+        responsibilities: "Updated responsibilities",
+        url: "https://updated-company.com",
+        achievements: [
+          {
+            id: createdCareer.achievements[0].id,
+            description: "Updated Achievement",
+            metrics: "Updated Metrics",
+          },
+          {
+            id: null,
+            description: "New Achievement",
+            metrics: null,
+          },
+        ],
+      };
+
+      // when
+      const updatedCareer = await updateCareerUseCase.updateCareer(
+        testUser.id,
+        createdCareer.id,
+        updateCareerData,
+      );
+
+      // then
+      expect(updatedCareer).toBeDefined();
+      expect(updatedCareer.companyName).toBe(updateCareerData.companyName);
+      expect(updatedCareer.position).toBe(updateCareerData.position);
+      expect(updatedCareer.employmentType).toBe(
+        updateCareerData.employmentType,
+      );
+      expect(updatedCareer.locationType).toBe(updateCareerData.locationType);
+      expect(updatedCareer.location).toBe(updateCareerData.location);
+      expect(updatedCareer.startDate).toStrictEqual(updateCareerData.startDate);
+      expect(updatedCareer.endDate).toStrictEqual(updateCareerData.endDate);
+      expect(updatedCareer.isCurrentPosition).toBe(
+        updateCareerData.isCurrentPosition,
+      );
+      expect(updatedCareer.description).toBe(updateCareerData.description);
+      expect(updatedCareer.responsibilities).toBe(
+        updateCareerData.responsibilities,
+      );
+      expect(updatedCareer.url).toBe(updateCareerData.url);
+
+      expect(updatedCareer.achievements.length).toBe(
+        updateCareerData.achievements.length,
+      );
+
+      updatedCareer.achievements.forEach((achievement, i) => {
+        expect(achievement).toBeDefined();
+        expect(achievement.description).toBe(
+          updateCareerData.achievements[i].description,
+        );
+        expect(achievement.metrics).toBe(
+          updateCareerData.achievements[i].metrics,
+        );
+      });
+    });
+  });
+});

--- a/src/server/application/port/in/career/update-career.use-case.ts
+++ b/src/server/application/port/in/career/update-career.use-case.ts
@@ -1,0 +1,12 @@
+import { CareerDto } from "~/server/application/dto/career.dto";
+import { UpdateCareerDataDto } from "~/server/application/dto/update-career-data.dto";
+
+export const UPDATE_CAREER_USE_CASE = Symbol.for("UpdateCareerUseCase");
+
+export interface UpdateCareerUseCase {
+  updateCareer(
+    userId: number,
+    careerId: number,
+    updateCareerData: UpdateCareerDataDto,
+  ): Promise<CareerDto>;
+}

--- a/src/server/application/port/out/repositories/career.repository.ts
+++ b/src/server/application/port/out/repositories/career.repository.ts
@@ -8,4 +8,6 @@ export interface CareerRepository {
     userId: number,
     createCareerData: CreateCareerDataDto,
   ): Promise<Career>;
+  findCareerById(careerId: number): Promise<Career | null>;
+  findCareersByUserId(userId: number): Promise<Career[]>;
 }

--- a/src/server/application/port/out/repositories/career.repository.ts
+++ b/src/server/application/port/out/repositories/career.repository.ts
@@ -1,0 +1,11 @@
+import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+import { Career } from "~/server/domain/aggregate/career/career.entity";
+
+export const CAREER_REPOSITORY = Symbol.for("CareerRepository");
+
+export interface CareerRepository {
+  createCareer(
+    userId: number,
+    createCareerData: CreateCareerDataDto,
+  ): Promise<Career>;
+}

--- a/src/server/application/port/out/repositories/career.repository.ts
+++ b/src/server/application/port/out/repositories/career.repository.ts
@@ -15,4 +15,5 @@ export interface CareerRepository {
     careerId: number,
     updateCareerData: UpdateCareerDataDto,
   ): Promise<Career>;
+  deleteCareer(careerId: number): Promise<void>;
 }

--- a/src/server/application/port/out/repositories/career.repository.ts
+++ b/src/server/application/port/out/repositories/career.repository.ts
@@ -1,4 +1,5 @@
 import { CreateCareerDataDto } from "~/server/application/dto/create-career-data.dto";
+import { UpdateCareerDataDto } from "~/server/application/dto/update-career-data.dto";
 import { Career } from "~/server/domain/aggregate/career/career.entity";
 
 export const CAREER_REPOSITORY = Symbol.for("CareerRepository");
@@ -10,4 +11,8 @@ export interface CareerRepository {
   ): Promise<Career>;
   findCareerById(careerId: number): Promise<Career | null>;
   findCareersByUserId(userId: number): Promise<Career[]>;
+  updateCareer(
+    careerId: number,
+    updateCareerData: UpdateCareerDataDto,
+  ): Promise<Career>;
 }

--- a/src/server/application/port/out/repositories/index.ts
+++ b/src/server/application/port/out/repositories/index.ts
@@ -8,3 +8,4 @@ export {
   PROJECT_REPOSITORY,
   type ProjectRepository,
 } from "./project.repository";
+export { CAREER_REPOSITORY, type CareerRepository } from "./career.repository";

--- a/src/server/application/services/career.service.ts
+++ b/src/server/application/services/career.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from "~/server/infra/core";
 import {
   CreateCareerUseCase,
+  DeleteCareerUseCase,
   GetCareerUseCase,
   UpdateCareerUseCase,
 } from "../port/in/career";
@@ -17,7 +18,11 @@ import { NotFoundError } from "~/shared/error/not-found.error";
 
 @Injectable()
 export class CareerService
-  implements CreateCareerUseCase, GetCareerUseCase, UpdateCareerUseCase
+  implements
+    CreateCareerUseCase,
+    GetCareerUseCase,
+    UpdateCareerUseCase,
+    DeleteCareerUseCase
 {
   constructor(
     @Inject(CAREER_REPOSITORY)
@@ -73,5 +78,19 @@ export class CareerService
     );
 
     return CareerMapper.toDto(updatedCareer);
+  }
+
+  async deleteCareer(userId: number, careerId: number): Promise<void> {
+    const career = await this.careerRepository.findCareerById(careerId);
+
+    if (!career) {
+      throw new NotFoundError();
+    }
+
+    if (career.userId !== userId) {
+      throw new ForbiddenError();
+    }
+
+    await this.careerRepository.deleteCareer(careerId);
   }
 }

--- a/src/server/application/services/career.service.ts
+++ b/src/server/application/services/career.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from "~/server/infra/core";
-import { CreateCareerUseCase } from "../port/in/career";
+import { CreateCareerUseCase, GetCareerUseCase } from "../port/in/career";
 import { CreateCareerDataDto } from "../dto/create-career-data.dto";
 import { CareerDto } from "../dto/career.dto";
 import {
@@ -9,7 +9,7 @@ import {
 import { CareerMapper } from "../mappers/career";
 
 @Injectable()
-export class CareerService implements CreateCareerUseCase {
+export class CareerService implements CreateCareerUseCase, GetCareerUseCase {
   constructor(
     @Inject(CAREER_REPOSITORY)
     private readonly careerRepository: CareerRepository,
@@ -25,5 +25,21 @@ export class CareerService implements CreateCareerUseCase {
     );
 
     return CareerMapper.toDto(career);
+  }
+
+  async getCareer(careerId: number): Promise<CareerDto | null> {
+    const career = await this.careerRepository.findCareerById(careerId);
+
+    if (!career) {
+      return null;
+    }
+
+    return CareerMapper.toDto(career);
+  }
+
+  async getCareersByUserId(userId: number): Promise<CareerDto[]> {
+    const careers = await this.careerRepository.findCareersByUserId(userId);
+
+    return careers.map(CareerMapper.toDto);
   }
 }

--- a/src/server/application/services/career.service.ts
+++ b/src/server/application/services/career.service.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from "~/server/infra/core";
+import { CreateCareerUseCase } from "../port/in/career";
+import { CreateCareerDataDto } from "../dto/create-career-data.dto";
+import { CareerDto } from "../dto/career.dto";
+import {
+  CAREER_REPOSITORY,
+  type CareerRepository,
+} from "../port/out/repositories";
+import { CareerMapper } from "../mappers/career";
+
+@Injectable()
+export class CareerService implements CreateCareerUseCase {
+  constructor(
+    @Inject(CAREER_REPOSITORY)
+    private readonly careerRepository: CareerRepository,
+  ) {}
+
+  async createCareer(
+    userId: number,
+    createCareerData: CreateCareerDataDto,
+  ): Promise<CareerDto> {
+    const career = await this.careerRepository.createCareer(
+      userId,
+      createCareerData,
+    );
+
+    return CareerMapper.toDto(career);
+  }
+}

--- a/src/server/application/services/index.ts
+++ b/src/server/application/services/index.ts
@@ -2,3 +2,4 @@ export { PostService } from "./post.service";
 export { PostDraftService } from "./post-draft.service";
 export { SkillService } from "./skill.service";
 export { ProjectService } from "./project.service";
+export { CareerService } from "./career.service";

--- a/src/server/domain/aggregate/career/career-archievement.entity.ts
+++ b/src/server/domain/aggregate/career/career-archievement.entity.ts
@@ -1,0 +1,28 @@
+interface CareerAchievementConstructorArgs {
+  id: number;
+  careerId: number;
+  description: string;
+  metrics: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class CareerAchievement {
+  id: number;
+  careerId: number;
+  description: string;
+  metrics: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+
+  constructor(args: CareerAchievementConstructorArgs) {
+    this.id = args.id;
+    this.careerId = args.careerId;
+    this.description = args.description;
+    this.metrics = args.metrics;
+    this.createdAt = args.createdAt;
+    this.updatedAt = args.updatedAt;
+  }
+}

--- a/src/server/domain/aggregate/career/career.entity.ts
+++ b/src/server/domain/aggregate/career/career.entity.ts
@@ -1,0 +1,64 @@
+import { LocationType } from "@prisma/client";
+import { EmploymentType } from "./employment-type.entity";
+import { CareerAchievement } from "./career-archievement.entity";
+
+interface CareerConstructorArgs {
+  id: number;
+  userId: number;
+  companyName: string;
+  position: string;
+  employmentType: EmploymentType;
+  locationType: LocationType;
+  location: string | null;
+  startDate: Date;
+  endDate: Date | null;
+  isCurrentPosition: boolean;
+  description: string | null;
+  responsibilities: string | null;
+  url: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  achievements: CareerAchievement[];
+}
+
+export class Career {
+  id: number;
+  userId: number;
+  companyName: string;
+  position: string;
+  employmentType: EmploymentType;
+  locationType: LocationType;
+  location: string | null;
+  startDate: Date;
+  endDate: Date | null;
+  isCurrentPosition: boolean;
+  description: string | null;
+  responsibilities: string | null;
+  url: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+
+  achievements: CareerAchievement[];
+
+  constructor(args: CareerConstructorArgs) {
+    this.id = args.id;
+    this.userId = args.userId;
+    this.companyName = args.companyName;
+    this.position = args.position;
+    this.employmentType = args.employmentType;
+    this.locationType = args.locationType;
+    this.location = args.location;
+    this.startDate = args.startDate;
+    this.endDate = args.endDate;
+    this.isCurrentPosition = args.isCurrentPosition;
+    this.description = args.description;
+    this.responsibilities = args.responsibilities;
+    this.url = args.url;
+    this.createdAt = args.createdAt;
+    this.updatedAt = args.updatedAt;
+    this.deletedAt = args.deletedAt;
+    this.achievements = args.achievements;
+  }
+}

--- a/src/server/domain/aggregate/career/employment-type.entity.ts
+++ b/src/server/domain/aggregate/career/employment-type.entity.ts
@@ -1,0 +1,7 @@
+export enum EmploymentType {
+  FullTime = "FullTime",
+  PartTime = "PartTime",
+  Contract = "Contract",
+  Internship = "Internship",
+  Freelance = "Freelance",
+}

--- a/src/server/domain/aggregate/career/index.ts
+++ b/src/server/domain/aggregate/career/index.ts
@@ -1,0 +1,1 @@
+export { Career } from "./career.entity";

--- a/src/server/domain/aggregate/career/location-type.entity.ts
+++ b/src/server/domain/aggregate/career/location-type.entity.ts
@@ -1,0 +1,5 @@
+export enum LocationType {
+  Office = "Office",
+  Remote = "Remote",
+  Hybrid = "Hybrid",
+}

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -4,6 +4,7 @@ import { container } from "tsyringe";
 import { PRISMA_SERVICE, PrismaService } from "../database/prisma.service";
 import { PostService } from "~/server/application/services/post.service";
 import {
+  CAREER_REPOSITORY,
   POST_DRAFT_REPOSITORY,
   POST_REPOSITORY,
   PROJECT_REPOSITORY,
@@ -38,10 +39,13 @@ import {
   PostDraftService,
   ProjectService,
   SkillService,
+  CareerService,
 } from "~/server/application/services";
+import { CREATE_CAREER_USE_CASE } from "~/server/application/port/in/career";
 import { PostRepositoryAdapter } from "~/server/adapter/out/persistence/post";
 import { SkillRepositoryAdapter } from "~/server/adapter/out/persistence/skill";
 import { ProjectRepositoryAdapter } from "~/server/adapter/out/persistence/project";
+import { CareerRepositoryAdapter } from "~/server/adapter/out/persistence/career";
 
 export const di = container;
 
@@ -53,6 +57,7 @@ di.registerSingleton(POST_DRAFT_REPOSITORY, PostDraftRepositoryAdapter);
 di.registerSingleton(POST_REPOSITORY, PostRepositoryAdapter);
 di.registerSingleton(SKILL_REPOSITORY, SkillRepositoryAdapter);
 di.registerSingleton(PROJECT_REPOSITORY, ProjectRepositoryAdapter);
+di.registerSingleton(CAREER_REPOSITORY, CareerRepositoryAdapter);
 
 // Service Providers
 // post draft service
@@ -78,3 +83,6 @@ di.registerSingleton(CREATE_PROJECT_USE_CASE, ProjectService);
 di.registerSingleton(GET_PROJECT_USE_CASE, ProjectService);
 di.registerSingleton(UPDATE_PROJECT_USE_CASE, ProjectService);
 di.registerSingleton(DELETE_PROJECT_USE_CASE, ProjectService);
+
+// career service
+di.registerSingleton(CREATE_CAREER_USE_CASE, CareerService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -44,6 +44,7 @@ import {
 import {
   CREATE_CAREER_USE_CASE,
   GET_CAREER_USE_CASE,
+  UPDATE_CAREER_USE_CASE,
 } from "~/server/application/port/in/career";
 import { PostRepositoryAdapter } from "~/server/adapter/out/persistence/post";
 import { SkillRepositoryAdapter } from "~/server/adapter/out/persistence/skill";
@@ -90,3 +91,4 @@ di.registerSingleton(DELETE_PROJECT_USE_CASE, ProjectService);
 // career service
 di.registerSingleton(CREATE_CAREER_USE_CASE, CareerService);
 di.registerSingleton(GET_CAREER_USE_CASE, CareerService);
+di.registerSingleton(UPDATE_CAREER_USE_CASE, CareerService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -43,6 +43,7 @@ import {
 } from "~/server/application/services";
 import {
   CREATE_CAREER_USE_CASE,
+  DELETE_CAREER_USE_CASE,
   GET_CAREER_USE_CASE,
   UPDATE_CAREER_USE_CASE,
 } from "~/server/application/port/in/career";
@@ -92,3 +93,4 @@ di.registerSingleton(DELETE_PROJECT_USE_CASE, ProjectService);
 di.registerSingleton(CREATE_CAREER_USE_CASE, CareerService);
 di.registerSingleton(GET_CAREER_USE_CASE, CareerService);
 di.registerSingleton(UPDATE_CAREER_USE_CASE, CareerService);
+di.registerSingleton(DELETE_CAREER_USE_CASE, CareerService);

--- a/src/server/infra/di/module.ts
+++ b/src/server/infra/di/module.ts
@@ -41,7 +41,10 @@ import {
   SkillService,
   CareerService,
 } from "~/server/application/services";
-import { CREATE_CAREER_USE_CASE } from "~/server/application/port/in/career";
+import {
+  CREATE_CAREER_USE_CASE,
+  GET_CAREER_USE_CASE,
+} from "~/server/application/port/in/career";
 import { PostRepositoryAdapter } from "~/server/adapter/out/persistence/post";
 import { SkillRepositoryAdapter } from "~/server/adapter/out/persistence/skill";
 import { ProjectRepositoryAdapter } from "~/server/adapter/out/persistence/project";
@@ -86,3 +89,4 @@ di.registerSingleton(DELETE_PROJECT_USE_CASE, ProjectService);
 
 // career service
 di.registerSingleton(CREATE_CAREER_USE_CASE, CareerService);
+di.registerSingleton(GET_CAREER_USE_CASE, CareerService);

--- a/src/shared/error/index.ts
+++ b/src/shared/error/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib";
 export { ForbiddenError } from "./forbidden.error";
+export { NotFoundError } from "./not-found.error";


### PR DESCRIPTION
## 변경사항
- Career 도메인 엔티티 및 DTO 구현
- Career CRUD 유스케이스 구현
  - Create Career
  - Read Career
  - Update Career
  - Delete Career
- Career Achievement 관련 기능 구현

## 주요 구현 내용

### 1. Career 도메인 모델
- `Career` 엔티티는 다음과 같은 주요 필드들을 포함합니다:
  - 회사명 (companyName)
  - 직책 (position)
  - 고용 형태 (employmentType)
  - 근무 형태 (locationType)
  - 근무 위치 (location)
  - 시작일/종료일 (startDate/endDate)
  - 현재 재직 여부 (isCurrentPosition)
  - 업무 설명 (description)
  - 주요 책임 (responsibilities)
  - 회사 URL (url)
  - 업적 목록 (achievements)

### 2. Career Achievement
- Career에 속한 주요 업적들을 관리할 수 있는 하위 엔티티 구현
- 각 업적은 제목, 설명, 날짜 정보를 포함

### 3. CRUD 유스케이스
- Clean Architecture 패턴을 따라 각 유스케이스 구현
- 트랜잭션 처리 및 에러 핸들링 구현
- 유스케이스 테스트 코드 작성

## 테스트
- 각 유스케이스별 단위 테스트 구현 완료
- 엣지 케이스 및 에러 상황에 대한 테스트 포함

## 리뷰 요청사항
1. Career 엔티티의 필드 구성이 적절한지 검토 부탁드립니다.
2. Achievement 엔티티와의 관계 설정이 적절한지 확인 부탁드립니다.
3. 유스케이스 구현 방식이 Clean Architecture 원칙을 잘 따르고 있는지 검토해주세요.